### PR TITLE
Support overriding bindkey, and using fd instead of find

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,19 @@ Shamelessly inspired from [@ael-code][ael] [zsh fasd plugin][0] ;)
 
 A zsh plugin to search in the local tree of subdirectories for files (just files! No directories nor links).
 
-It is powered by [fzf][1] and optionally [bat][2] (otherwise falls back to `cat`).
+It is powered by [fzf][1], and supports [bat][2] and [fd][3] (falling back to `cat` and `find`).
 
-The quick jump functionality is bound on ALT-e shortcut.
+The quick jump functionality is bound on ALT-e shortcut, but can be overridden by exporting `FZF_FINDER_BINDKEY` before sourcing
 
 ## Install
 ### Antigen
 ```
 antigen bundle leophys/zsh-plugin-fzf-finder
+```
+
+### zr
+```
+zr load leophys/zsh-plugin-fzf-finder
 ```
 
 ## Screenshot
@@ -22,3 +27,4 @@ antigen bundle leophys/zsh-plugin-fzf-finder
 [0]: https://github.com/ael-code/zsh-plugin-fasd-fzf
 [1]: https://github.com/junegunn/fzf
 [2]: https://github.com/sharkdp/bat
+[3]: https://github.com/sharkdp/fd

--- a/fzf-finder.plugin.zsh
+++ b/fzf-finder.plugin.zsh
@@ -1,34 +1,31 @@
-if [[ $commands[bat] ]]; then
-    CAT='bat --color always {}'
-else
-    CAT='cat {}'
-fi
+(( $+commands[fzf] )) || return
+(( $+functions[fzf-find-widget] )) && return
+(( $+commands[fzf-tmux] )) || return
 
-if [[ -z $EDITOR ]]; then
-    EDITOR=vim
-fi
+(( $+commands[bat] )) && FZF_FINDER_CAT='bat --color always {}' || FZF_FINDER_CAT='cat {}'
 
-if [[ $commands[fzf] ]]; then
-    fzf-find-widget() {
-        local target
-        target="$(find * -type f -not -path './.git/*\'| \
-            fzf-tmux -1 -0 \
-            --no-sort \
-            --ansi \
-            --reverse \
-            --toggle-sort=ctrl-r \
-            --preview $CAT \
-            )" \
-        && if [[ -z $TMUX ]]; then \
-            $EDITOR "${target}"; \
-         else \
-            tmux new-window $EDITOR "${target}"; \
-         fi
-        local ret=$?
-        zle reset-prompt
-          typeset -f zle-line-init >/dev/null && zle zle-line-init
-        return $ret
-    }
-    zle -N fzf-find-widget
-    bindkey '\ee' fzf-find-widget
-fi
+fzf-finder-find() { (( $+commands[fd] )) && $commands[fd] -t f || find * -type f -not -path './.git/*\' }
+
+fzf-finder-widget() {
+    local target
+    target="$(fzf-finder-find | \
+        fzf-tmux -1 -0 \
+        --no-sort \
+        --ansi \
+        --reverse \
+        --toggle-sort=ctrl-r \
+        --preview $FZF_FINDER_CAT \
+        )" \
+    && if [[ -z $TMUX ]]; then \
+        $FZF_FINDER_EDITOR "${target}"; \
+     else \
+        tmux new-window ${EDITOR:-vim} "${target}"; \
+     fi
+    local ret=$?
+    zle reset-prompt
+      typeset -f zle-line-init >/dev/null && zle zle-line-init
+    return $ret
+}
+
+zle -N fzf-finder-widget
+bindkey ${FZF_FINDER_BINDKEY:-'\ee'} fzf-finder-widget


### PR DESCRIPTION
For example, I use ^B for binding by doing:

    export FZF_FINDER_BINDKEY='^B'

I also prefixed all plugin variables with FZF_FINDER_ so we don't accidentally override things (not that it did before but just in case the plugin got loaded in a weird order from other ENV variables by a user).