### PR TITLE
feat: allow custom fd and find arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ The quick jump functionality is bound on
 but can be overridden by exporting `FZF_FINDER_EDITOR_BINDKEY` and/or
 `FZF_FINDER_PAGER_BINDKEY` before sourcing
 
+Custom arguments for `fd` and `find` can be passed by setting respectively `FZF_FINDER_FD_OPTS` and `FZF_FINDER_FIND_OPTS`.
+For example, adding `export FZF_FINDER_FD_OPTS="--hidden -t f"` to your `.zshrc` will make `fd` search for hidden files.
+
 ## Install
 ### Antigen
 ```

--- a/fzf-finder.plugin.zsh
+++ b/fzf-finder.plugin.zsh
@@ -8,7 +8,23 @@ if [[ -z $FZF_FINDER_PAGER ]]; then
     (( $+commands[bat] )) && FZF_FINDER_PAGER='bat' || FZF_FINDER_PAGER='less'
 fi
 
-fzf-finder-find() { (( $+commands[fd] )) && $commands[fd] -t f || find * -type f -not -path './.git/*\' }
+fzf-finder-find() { 
+    if (( $+commands[fd] )); then 
+        if (( $+FZF_FINDER_FD_OPTS )); then
+            FINDER_OPTS=$FZF_FINDER_FD_OPTS
+        else 
+            FINDER_OPTS='-t f'
+        fi
+        $commands[fd] $(echo $FINDER_OPTS ) 
+    else 
+        if (( $+FZF_FINDER_FIND_OPTS )); then
+            FINDER_OPTS=$FZF_FINDER_FIND_OPTS
+        else
+            FINDER_OPTS="-type f -not -path './.git/*\'"  
+        fi
+        find * $(echo $FINDER_OPTS)
+    fi
+}
 
 fzf-finder-widget-editor() {
     local target


### PR DESCRIPTION
HI ! 

I wanted to search hidden files too, so I made this little change to the plugin. Since it does not really change its base behavior if  users set nothing, I thought I might as well ask if youd like to put the changes in the main project :) 

This PR update the `fzf-finder-find`  function to lookup custom arguments for `fd` and `find` in env. If found , they would replace the default ones left as is. If not defined, the behavior of this plugin stay the same.






